### PR TITLE
ENH: add benchmark figure for anomaly in UV-vis

### DIFF
--- a/production_figures/figure_uvvis_anomaly.ipynb
+++ b/production_figures/figure_uvvis_anomaly.ipynb
@@ -1,0 +1,316 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "%config Completer.use_jedi = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "sys.path.append(\"..\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from itertools import product\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib as mpl\n",
+    "from matplotlib import cm\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import plotly.graph_objects as go\n",
+    "from scipy.spatial import distance_matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sva import utils\n",
+    "from sva.truth.uv import truth_uv\n",
+    "from sva.value import default_asymmetric_value_function\n",
+    "from sva.experiments import UVData, UVExperiment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set some plotting defaults."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "utils.set_defaults()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# UV-vis experiment results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(\"../sva/truth/uv_data.csv\")\n",
+    "df = df.drop_duplicates(subset=[\"NCit\", \"pH\", \"HA\"])\n",
+    "X = df[[\"NCit\", \"pH\", \"HA\"]].to_numpy()\n",
+    "Y = df.iloc[:, 4:].to_numpy()\n",
+    "grid = np.array([float(xx) for xx in df.columns.tolist()[4:]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Anomaly detection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## LocalOutlierFactor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.neighbors import LocalOutlierFactor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lof = LocalOutlierFactor(novelty=False)\n",
+    "lof.fit_predict(X)\n",
+    "U = lof.negative_outlier_factor_ * -1\n",
+    "U_lof = (U - U.min()) / (U.max() - U.min())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Covariance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.covariance import EllipticEnvelope"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cov = EllipticEnvelope().fit(X)\n",
+    "U = cov.score_samples(X)\n",
+    "U_cov = (U - U.min()) / (U.max() - U.min())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Plots"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Borrowing the clusters from the original analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "low_value_cluster_1 = np.array([[2, -16, 2], [1, -16, 2]])\n",
+    "low_value_cluster_2 = np.array([[6, -16, 16], [7, -16, 14], [5.25, -16, 14]])\n",
+    "low_value_cluster_3 = np.array([[12, 16, 11], [11, 16, 11]])\n",
+    "low_value_cluster_4 = np.array([[1, 16, 2], [2, 16, 2]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "highest_value_point = X[np.argmax(U), :]\n",
+    "distances_to_highest_value_point = distance_matrix(highest_value_point.reshape(-1, 3), X).squeeze()\n",
+    "argsorted = np.argsort(distances_to_highest_value_point)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_closest_points = 10\n",
+    "high_value_cluster = X[argsorted, :][:n_closest_points, :]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_indexes_by_cluster(cluster, X=X):\n",
+    "    indexes = []\n",
+    "    for point in cluster:\n",
+    "        where = np.all(X == point, axis=1)\n",
+    "        where = np.where(where)[0].item()\n",
+    "        indexes.append(where)\n",
+    "    return np.array(indexes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "low_value_spectra = [\n",
+    "    Y[get_indexes_by_cluster(low_value_cluster_1), :],\n",
+    "    Y[get_indexes_by_cluster(low_value_cluster_2), :],\n",
+    "    Y[get_indexes_by_cluster(low_value_cluster_3), :],\n",
+    "    Y[get_indexes_by_cluster(low_value_cluster_4), :],\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "low_value_value = [\n",
+    "    U[get_indexes_by_cluster(low_value_cluster_1)],\n",
+    "    U[get_indexes_by_cluster(low_value_cluster_2)],\n",
+    "    U[get_indexes_by_cluster(low_value_cluster_3)],\n",
+    "    U[get_indexes_by_cluster(low_value_cluster_4)],\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "high_value_spectra = Y[get_indexes_by_cluster(high_value_cluster), :]\n",
+    "high_value_value = U[get_indexes_by_cluster(high_value_cluster)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prop_cycle = plt.rcParams[\"axes.prop_cycle\"]\n",
+    "colors = prop_cycle.by_key()[\"color\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(2, 1, figsize=(5, 10), subplot_kw={\"projection\": \"3d\"}, tight_layout=True)\n",
+    "axes = axes.ravel()\n",
+    "\n",
+    "for title, U, ax in zip([\"Local Outlier Factor\", \"Elliptic Envelope\"], [U_lof, U_cov], axes):\n",
+    "    ax.scatter(*low_value_cluster_1.T, color=colors[0], alpha=1, marker=\"o\", s=50)\n",
+    "    ax.scatter(*low_value_cluster_2.T, color=colors[1], alpha=1, marker=\"o\", s=50)\n",
+    "    ax.scatter(*low_value_cluster_3.T, color=colors[2], alpha=1, marker=\"o\", s=50)\n",
+    "    ax.scatter(*low_value_cluster_4.T, color=colors[3], alpha=1, marker=\"o\", s=50)\n",
+    "    # ax.scatter(*high_value_cluster.T, color=\"black\", alpha=1, marker=\"o\", s=50)\n",
+    "    ax.scatter(X[:, 0], X[:, 1], X[:, 2], c=U, alpha=0.9, marker=\"o\", s=20)\n",
+    "\n",
+    "    ax.set_box_aspect((np.ptp(X[:, 0]), np.ptp(X[:, 1]), np.ptp(X[:, 2])))\n",
+    "    ax.view_init(40, 225)\n",
+    "    ax.set_xlabel(\"Volume NaCit [$\\mu$L]\")\n",
+    "    ax.set_ylabel(\"Volume OH$^-$ [$\\mu$L]\", labelpad=20)\n",
+    "    ax.set_zlabel(\"Volume HAuCl$_4$ [$\\mu$L]\")\n",
+    "\n",
+    "    ax.set_zticks([2, 6, 10, 14])\n",
+    "    ax.set_xticks([2, 6, 10, 14])\n",
+    "\n",
+    "    ax.set_title(title)\n",
+    "\n",
+    "# plt.show()\n",
+    "fig.savefig(\"uv_anomaly_det.pdf\", dpi=300, bbox_inches=\"tight\", pad_inches=0.5)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Figure to compare this against two common anomaly/outlier detection methods. I use the same point highlights for direct comparison to main paper. 

Takeaways: 
1. Both miss the region of drastic change in the center of the search space. 
2. The also both consider regions that are very different from the mean (in spectral space) to be outliers (rightfully so), so are not attentive to how things are changing. Measuring once would be sufficient, but these methods would suggest revisiting. They are valuable, but for a different purpose. 

Resultant figure:
[uv_anomaly_det.pdf](https://github.com/matthewcarbone/ScientificValueAgent/files/12527986/uv_anomaly_det.pdf)
